### PR TITLE
allow decimal version 1 or 2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,7 @@ defmodule PgRanges.MixProject do
     [
       {:postgrex, ">= 0.0.0"},
       {:ecto_sql, ">= 3.3.0"},
-      {:decimal, "~> 1.0"},
+      {:decimal, "~> 1.0 or ~> 2.0"},
 
       # dev/test deps
       {:tzdata, "~> 1.0", only: [:dev, :test]},


### PR DESCRIPTION
I tried installing pg_ranges on a newly generated phoenix project, and I got this error:

```
$ mix deps.get
Resolving Hex dependencies...

Failed to use "decimal" because
  jason (version 1.4.0) requires ~> 1.0 or ~> 2.0 *
  pg_ranges (version 1.1.0) requires ~> 1.0 *
  mix.lock specifies 2.0.0

* This requirement does not match pre-releases. To match pre-releases include a pre-release in the requirement, such as: "~> 2.0-beta".

** (Mix) Hex dependency resolution failed, change the version requirements of your dependencies or unlock them (by using mix deps.update or mix deps.unlock). If you are unable to resolve the conflicts you can try overriding with {:dependency, "~> 1.0", override: true}
```

I could probably fix this in my project by downgrading the version in my mix.lock file, but I'd rather use the latest version of decimal, so I'm submitting this PR.

It looks like pg_ranges uses the following functions from the Decimal package:

- `Decimal.new/1`
- `Decimal.from_float/1`

I don't think that anything in the [changelog for v2](https://github.com/ericmj/decimal/blob/master/CHANGELOG.md) matters for this project, since we already handle cases where the value is a float with `from_float`. Also, I've run the tests for this project locally with both v1 and v2 and it passes.

