### PR TITLE
Override `equal?` for time based ranges

### DIFF
--- a/lib/pg_ranges/daterange.ex
+++ b/lib/pg_ranges/daterange.ex
@@ -12,6 +12,15 @@ defmodule PgRanges.DateRange do
         }
 
   @doc false
+  @impl true
   @spec type() :: :daterange
   def type, do: :daterange
+
+  @impl true
+  def equal?(%__MODULE__{} = left, %__MODULE__{} = right) do
+    Date.compare(left.lower, right.lower) == :eq and
+      left.lower_inclusive == right.lower_inclusive and
+      Date.compare(left.upper, right.upper) == :eq and
+      left.upper_inclusive == right.upper_inclusive
+  end
 end

--- a/lib/pg_ranges/tsrange.ex
+++ b/lib/pg_ranges/tsrange.ex
@@ -12,6 +12,17 @@ defmodule PgRanges.TsRange do
         }
 
   @doc false
+  @impl true
   @spec type() :: :tsrange
   def type, do: :tsrange
+
+  @impl true
+  def equal?(%__MODULE__{} = left, %__MODULE__{} = right) do
+    DateTime.compare(left.lower, right.lower) == :eq and
+      left.lower_inclusive == right.lower_inclusive and
+      DateTime.compare(left.upper, right.upper) == :eq and
+      left.upper_inclusive == right.upper_inclusive
+  end
+
+  def equal?(_, _), do: false
 end

--- a/lib/pg_ranges/tstzrange.ex
+++ b/lib/pg_ranges/tstzrange.ex
@@ -36,4 +36,14 @@ defmodule PgRanges.TstzRange do
 
     struct!(__MODULE__, fields)
   end
+
+  @impl true
+  def equal?(%__MODULE__{} = left, %__MODULE__{} = right) do
+    DateTime.compare(left.lower, right.lower) == :eq and
+      left.lower_inclusive == right.lower_inclusive and
+      DateTime.compare(left.upper, right.upper) == :eq and
+      left.upper_inclusive == right.upper_inclusive
+  end
+
+  def equal?(_, _), do: false
 end


### PR DESCRIPTION
Hello!

First off - thanks for this project, it has been invaluable in our application and we really appreciate the work you have put into this.  We recently ran into a small issue caused by the default (provided by Ecto.Type) implementation of `TsRange.equal?`.  The default implementation simple checks for strict equality (`==`) which is not recommended for for Date/DateTime structs (per the elixir docs `Remember, comparisons in Elixir using == and friends are structural and based on the DateTime struct fields. For proper comparison between datetimes, use the compare/2 function.`)

This PR adds an override for the `equal?` function for TsRange, TstzRange and DateRange.  Let me know if you would like to see any changes to this, or feel free to reject it entirely if you do not find this to be a positive addition to the project