### PR TITLE
Allow open-ended ranges

### DIFF
--- a/lib/pg_ranges/daterange.ex
+++ b/lib/pg_ranges/daterange.ex
@@ -5,9 +5,9 @@ defmodule PgRanges.DateRange do
   use PgRanges
 
   @type t :: %__MODULE__{
-          lower: Date.t(),
+          lower: Date.t() | :unbound | :empty,
           lower_inclusive: integer(),
-          upper: Date.t(),
+          upper: Date.t() | :unbound | :empty,
           upper_inclusive: integer()
         }
 

--- a/lib/pg_ranges/int4range.ex
+++ b/lib/pg_ranges/int4range.ex
@@ -5,9 +5,9 @@ defmodule PgRanges.Int4Range do
   use PgRanges
 
   @type t :: %__MODULE__{
-          lower: integer(),
+          lower: integer() | :unbound | :empty,
           lower_inclusive: boolean(),
-          upper: integer(),
+          upper: integer() | :unbound | :empty,
           upper_inclusive: boolean()
         }
 

--- a/lib/pg_ranges/int8range.ex
+++ b/lib/pg_ranges/int8range.ex
@@ -5,9 +5,9 @@ defmodule PgRanges.Int8Range do
   use PgRanges
 
   @type t :: %__MODULE__{
-          lower: integer(),
+          lower: integer() | :unbound | :empty,
           lower_inclusive: boolean(),
-          upper: integer(),
+          upper: integer() | :unbound | :empty,
           upper_inclusive: boolean()
         }
 

--- a/lib/pg_ranges/numrange.ex
+++ b/lib/pg_ranges/numrange.ex
@@ -5,9 +5,9 @@ defmodule PgRanges.NumRange do
   use PgRanges
 
   @type t :: %__MODULE__{
-          lower: float(),
+          lower: float() | :unbound | :empty,
           lower_inclusive: boolean(),
-          upper: float(),
+          upper: float() | :unbound | :empty,
           upper_inclusive: boolean()
         }
 
@@ -92,6 +92,9 @@ defmodule PgRanges.NumRange do
     struct!(__MODULE__, fields)
   end
 
+  defp to_decimal(value)
+  defp to_decimal(:unbound), do: :unbound
+  defp to_decimal(:empty), do: :empty
   defp to_decimal(value) when is_float(value), do: Decimal.from_float(value)
   defp to_decimal(value), do: Decimal.new(value)
 end

--- a/lib/pg_ranges/tsrange.ex
+++ b/lib/pg_ranges/tsrange.ex
@@ -5,9 +5,9 @@ defmodule PgRanges.TsRange do
   use PgRanges
 
   @type t :: %__MODULE__{
-          lower: NaiveDateTime.t(),
+          lower: NaiveDateTime.t() | :unbound | :empty,
           lower_inclusive: boolean(),
-          upper: NaiveDateTime.t(),
+          upper: NaiveDateTime.t() | :unbound | :empty,
           upper_inclusive: boolean()
         }
 

--- a/lib/pg_ranges/tstzrange.ex
+++ b/lib/pg_ranges/tstzrange.ex
@@ -5,9 +5,9 @@ defmodule PgRanges.TstzRange do
   use PgRanges
 
   @type t :: %__MODULE__{
-          lower: DateTime.t(),
+          lower: DateTime.t() | :unbound | :empty,
           lower_inclusive: boolean(),
-          upper: DateTime.t(),
+          upper: DateTime.t() | :unbound | :empty,
           upper_inclusive: boolean()
         }
 
@@ -29,11 +29,21 @@ defmodule PgRanges.TstzRange do
   @impl true
   def new(lower, upper, opts \\ []) do
     time_zone_database = Keyword.get(opts, :time_zone_database, Calendar.get_time_zone_database())
-    {:ok, lower} = DateTime.shift_zone(lower, "Etc/UTC", time_zone_database)
-    {:ok, upper} = DateTime.shift_zone(upper, "Etc/UTC", time_zone_database)
+
+    lower = shift_to_utc(lower, time_zone_database)
+    upper = shift_to_utc(upper, time_zone_database)
 
     fields = Keyword.merge(opts, lower: lower, upper: upper)
 
     struct!(__MODULE__, fields)
+  end
+
+  defp shift_to_utc(date_time, time_zone_database)
+  defp shift_to_utc(:unbound, _time_zone_database), do: :unbound
+  defp shift_to_utc(:empty, _time_zone_database), do: :empty
+
+  defp shift_to_utc(date_time, time_zone_database) do
+    {:ok, date_time} = DateTime.shift_zone(date_time, "UTC", time_zone_database)
+    date_time
   end
 end

--- a/lib/pg_ranges/tstzrange.ex
+++ b/lib/pg_ranges/tstzrange.ex
@@ -43,7 +43,8 @@ defmodule PgRanges.TstzRange do
   defp shift_to_utc(:empty, _time_zone_database), do: :empty
 
   defp shift_to_utc(date_time, time_zone_database) do
-    {:ok, date_time} = DateTime.shift_zone(date_time, "UTC", time_zone_database)
+    {:ok, date_time} = DateTime.shift_zone(date_time, "Etc/UTC", time_zone_database)
+
     date_time
   end
 end

--- a/test/pg_ranges_test.exs
+++ b/test/pg_ranges_test.exs
@@ -146,7 +146,7 @@ defmodule PgRanges.PgRangesTest do
     assert length(models) == 0
   end
 
-  test "can handle open ended ranges" do
+  test "can handle lower and upper open ended ranges" do
     assert {:ok, _model} =
              Model.changeset(%Model{}, %{
                date: DateRange.new(:unbound, :unbound),
@@ -165,6 +165,65 @@ defmodule PgRanges.PgRangesTest do
              int4: %Int4Range{lower: :unbound, upper: :unbound},
              int8: %Int8Range{lower: :unbound, upper: :unbound},
              num: %NumRange{lower: :unbound, upper: :unbound}
+           } = Repo.one(Model)
+  end
+
+  test "can handle lower open ended ranges" do
+    date_range = DateRange.new(~D[2018-04-21], :unbound)
+    ts_range = TsRange.new(~N[2018-04-21 15:00:00.000000], :unbound)
+    tstz_range = TstzRange.new(~U[2018-04-21 20:00:00.000000Z], :unbound)
+
+    int4_range = Int4Range.new(0, :unbound)
+    int8_range = Int8Range.new(0, :unbound)
+    num_range = NumRange.new(0, :unbound)
+
+    assert {:ok, _model} =
+             Model.changeset(%Model{}, %{
+               date: date_range,
+               ts: ts_range,
+               tstz: tstz_range,
+               int4: int4_range,
+               int8: int8_range,
+               num: num_range
+             })
+             |> Repo.insert()
+
+    assert %Model{
+             date: ^date_range,
+             ts: ^ts_range,
+             tstz: ^tstz_range,
+             int4: ^int4_range,
+             int8: ^int8_range,
+             num: ^num_range
+           } = Repo.one(Model)
+  end
+
+  test "can handle upper open ended ranges" do
+    date_range = DateRange.new(:unbound, ~D[2018-04-21], lower_inclusive: false)
+    ts_range = TsRange.new(:unbound, ~N[2018-04-21 15:00:00.000000], lower_inclusive: false)
+    tstz_range = TstzRange.new(:unbound, ~U[2018-04-21 20:00:00.000000Z], lower_inclusive: false)
+    int4_range = Int4Range.new(:unbound, 0, lower_inclusive: false)
+    int8_range = Int8Range.new(:unbound, 0, lower_inclusive: false)
+    num_range = NumRange.new(:unbound, 0, lower_inclusive: false)
+
+    assert {:ok, _model} =
+             Model.changeset(%Model{}, %{
+               date: date_range,
+               ts: ts_range,
+               tstz: tstz_range,
+               int4: int4_range,
+               int8: int8_range,
+               num: num_range
+             })
+             |> Repo.insert()
+
+    assert %Model{
+             date: ^date_range,
+             ts: ^ts_range,
+             tstz: ^tstz_range,
+             int4: ^int4_range,
+             int8: ^int8_range,
+             num: ^num_range
            } = Repo.one(Model)
   end
 
@@ -187,6 +246,28 @@ defmodule PgRanges.PgRangesTest do
              int4: %Int4Range{lower: :empty, upper: :empty},
              int8: %Int8Range{lower: :empty, upper: :empty},
              num: %NumRange{lower: :empty, upper: :empty}
+           } = Repo.one(Model)
+  end
+
+  test "can handle open ended ranges" do
+    assert {:ok, _model} =
+             Model.changeset(%Model{}, %{
+               date: DateRange.new(:unbound, :unbound),
+               ts: TsRange.new(:unbound, :unbound),
+               tstz: TstzRange.new(:unbound, :unbound),
+               int4: Int4Range.new(:unbound, :unbound),
+               int8: Int8Range.new(:unbound, :unbound),
+               num: NumRange.new(:unbound, :unbound)
+             })
+             |> Repo.insert()
+
+    assert %Model{
+             date: %DateRange{lower: :unbound, upper: :unbound},
+             ts: %TsRange{lower: :unbound, upper: :unbound},
+             tstz: %TstzRange{lower: :unbound, upper: :unbound},
+             int4: %Int4Range{lower: :unbound, upper: :unbound},
+             int8: %Int8Range{lower: :unbound, upper: :unbound},
+             num: %NumRange{lower: :unbound, upper: :unbound}
            } = Repo.one(Model)
   end
 end

--- a/test/pg_ranges_test.exs
+++ b/test/pg_ranges_test.exs
@@ -20,57 +20,62 @@ defmodule PgRanges.PgRangesTest do
     NumMultirange
   }
 
-  setup do
-    date_range = DateRange.new(~D[2018-04-21], ~D[2018-04-22])
-    ts_range = TsRange.new(~N[2018-04-21 15:00:00], ~N[2018-04-22 01:00:00])
+  setup tags do
+    if tags[:setup_test_model] do
+      date_range = DateRange.new(~D[2018-04-21], ~D[2018-04-22])
+      ts_range = TsRange.new(~N[2018-04-21 15:00:00], ~N[2018-04-22 01:00:00])
 
-    tstz_range =
-      TstzRange.new(
-        DateTime.from_naive!(~N[2018-04-21 15:00:00], "America/Chicago"),
-        DateTime.from_naive!(~N[2018-04-22 01:00:00], "America/Chicago")
-      )
+      tstz_range =
+        TstzRange.new(
+          DateTime.from_naive!(~N[2018-04-21 15:00:00], "America/Chicago"),
+          DateTime.from_naive!(~N[2018-04-22 01:00:00], "America/Chicago")
+        )
 
-    int4_range = Int4Range.new(0, 10)
-    int8_range = Int8Range.new(0, 1_000_000_000)
-    num_range = NumRange.new(0, 9.9, upper_inclusive: true)
+      int4_range = Int4Range.new(0, 10)
+      int8_range = Int8Range.new(0, 1_000_000_000)
+      num_range = NumRange.new(0, 9.9, upper_inclusive: true)
 
-    now = DateTime.utc_now()
+      now = DateTime.utc_now()
 
-    date_multi = DateMultirange.new([date_range, DateRange.new(~D[2018-04-23], ~D[2018-04-24])])
+      date_multi = DateMultirange.new([date_range, DateRange.new(~D[2018-04-23], ~D[2018-04-24])])
 
-    ts_multi =
-      TsMultirange.new([ts_range, TsRange.new(~N[2018-04-23 15:00:00], ~N[2018-04-24 01:00:00])])
+      ts_multi =
+        TsMultirange.new([ts_range, TsRange.new(~N[2018-04-23 15:00:00], ~N[2018-04-24 01:00:00])])
 
-    tstz_multirange =
-      TstzMultirange.new([
-        TstzRange.new(now, DateTime.add(now, 1, :hour)),
-        TstzRange.new(DateTime.add(now, 2, :hour), DateTime.add(now, 3, :hour))
-      ])
+      tstz_multirange =
+        TstzMultirange.new([
+          TstzRange.new(now, DateTime.add(now, 1, :hour)),
+          TstzRange.new(DateTime.add(now, 2, :hour), DateTime.add(now, 3, :hour))
+        ])
 
-    int4_multi = Int4Multirange.new([int4_range, Int4Range.new(11, 20)])
-    int8_multi = Int8Multirange.new([int8_range, Int8Range.new(1_000_000_001, 2_000_000_000)])
-    num_multi = NumMultirange.new([num_range, NumRange.new(10.0, 19.9, upper_inclusive: true)])
+      int4_multi = Int4Multirange.new([int4_range, Int4Range.new(11, 20)])
+      int8_multi = Int8Multirange.new([int8_range, Int8Range.new(1_000_000_001, 2_000_000_000)])
+      num_multi = NumMultirange.new([num_range, NumRange.new(10.0, 19.9, upper_inclusive: true)])
 
-    {:ok, m} =
-      Model.changeset(%Model{}, %{
-        date: date_range,
-        ts: ts_range,
-        tstz: tstz_range,
-        int4: int4_range,
-        int8: int8_range,
-        num: num_range,
-        datemulti: date_multi,
-        tsmulti: ts_multi,
-        tstzmulti: tstz_multirange,
-        int4multi: int4_multi,
-        int8multi: int8_multi,
-        nummulti: num_multi
-      })
-      |> Repo.insert()
+      {:ok, m} =
+        Model.changeset(%Model{}, %{
+          date: date_range,
+          ts: ts_range,
+          tstz: tstz_range,
+          int4: int4_range,
+          int8: int8_range,
+          num: num_range,
+          datemulti: date_multi,
+          tsmulti: ts_multi,
+          tstzmulti: tstz_multirange,
+          int4multi: int4_multi,
+          int8multi: int8_multi,
+          nummulti: num_multi
+        })
+        |> Repo.insert()
 
-    {:ok, model: m, now: now}
+      {:ok, model: m, now: now}
+    else
+      :ok
+    end
   end
 
+  @tag :setup_test_model
   test "querying" do
     range = Int4Range.new(1, 4)
 
@@ -80,6 +85,7 @@ defmodule PgRanges.PgRangesTest do
     assert length(models) == 1
   end
 
+  @tag :setup_test_model
   test "querying tstzrange" do
     tzdb = Calendar.get_time_zone_database()
 
@@ -106,6 +112,7 @@ defmodule PgRanges.PgRangesTest do
     assert length(models) == 0
   end
 
+  @tag :setup_test_model
   test "querying tstzmultirange", %{now: now} do
     inside1 = DateTime.add(now, 30, :minute)
     inside2 = DateTime.add(now, 150, :minute)
@@ -137,5 +144,49 @@ defmodule PgRanges.PgRangesTest do
       )
 
     assert length(models) == 0
+  end
+
+  test "can handle open ended ranges" do
+    assert {:ok, _model} =
+             Model.changeset(%Model{}, %{
+               date: DateRange.new(:unbound, :unbound),
+               ts: TsRange.new(:unbound, :unbound),
+               tstz: TstzRange.new(:unbound, :unbound),
+               int4: Int4Range.new(:unbound, :unbound),
+               int8: Int8Range.new(:unbound, :unbound),
+               num: NumRange.new(:unbound, :unbound)
+             })
+             |> Repo.insert()
+
+    assert %Model{
+             date: %DateRange{lower: :unbound, upper: :unbound},
+             ts: %TsRange{lower: :unbound, upper: :unbound},
+             tstz: %TstzRange{lower: :unbound, upper: :unbound},
+             int4: %Int4Range{lower: :unbound, upper: :unbound},
+             int8: %Int8Range{lower: :unbound, upper: :unbound},
+             num: %NumRange{lower: :unbound, upper: :unbound}
+           } = Repo.one(Model)
+  end
+
+  test "can handle empty range" do
+    assert {:ok, _model} =
+             Model.changeset(%Model{}, %{
+               date: DateRange.new(:empty, :empty),
+               ts: TsRange.new(:empty, :empty),
+               tstz: TstzRange.new(:empty, :empty),
+               int4: Int4Range.new(:empty, :empty),
+               int8: Int8Range.new(:empty, :empty),
+               num: NumRange.new(:empty, :empty)
+             })
+             |> Repo.insert()
+
+    assert %Model{
+             date: %DateRange{lower: :empty, upper: :empty},
+             ts: %TsRange{lower: :empty, upper: :empty},
+             tstz: %TstzRange{lower: :empty, upper: :empty},
+             int4: %Int4Range{lower: :empty, upper: :empty},
+             int8: %Int8Range{lower: :empty, upper: :empty},
+             num: %NumRange{lower: :empty, upper: :empty}
+           } = Repo.one(Model)
   end
 end


### PR DESCRIPTION
Handle empty and unbound ranges.

See:
* [`Postgrex.Range.t/0`](https://hexdocs.pm/postgrex/Postgrex.Range.html#t:t/0)
* [Postgres Infinite Ranges](https://www.postgresql.org/docs/current/rangetypes.html#RANGETYPES-INFINITE)
* [Postgres Empty Ranges](https://www.postgresql.org/docs/current/rangetypes.html#RANGETYPES-IO)