### PR TITLE
Allow open-ended ranges, adjust defaults to default elixir behaviour

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -3,9 +3,9 @@ import Config
 config :elixir, :time_zone_database, Tzdata.TimeZoneDatabase
 
 config :pg_ranges, PgRanges.Repo,
-  username: System.get_env("POSTGRES_USERNAME", "postgres"),
-  password: System.get_env("POSTGRES_PASSWORD", "postgres"),
-  database: System.get_env("POSTGRES_DATABASE", "postgres"),
+  username: System.get_env("POSTGRES_USERNAME", "najapi"),
+  password: System.get_env("POSTGRES_PASSWORD", "passwrod"),
+  database: System.get_env("POSTGRES_DATABASE", "najapi_dev"),
   hostname: System.get_env("POSTGRES_HOSTNAME", "localhost"),
   pool_size: 10,
   pool: Ecto.Adapters.SQL.Sandbox

--- a/lib/pg_ranges/daterange.ex
+++ b/lib/pg_ranges/daterange.ex
@@ -5,9 +5,9 @@ defmodule PgRanges.DateRange do
   use PgRanges
 
   @type t :: %__MODULE__{
-          lower: Date.t(),
+          lower: Date.t() | :unbound | :empty,
           lower_inclusive: integer(),
-          upper: Date.t(),
+          upper: Date.t() | :unbound | :empty,
           upper_inclusive: integer()
         }
 

--- a/lib/pg_ranges/int4range.ex
+++ b/lib/pg_ranges/int4range.ex
@@ -5,9 +5,9 @@ defmodule PgRanges.Int4Range do
   use PgRanges
 
   @type t :: %__MODULE__{
-          lower: integer(),
+          lower: integer() | :unbound | :empty,
           lower_inclusive: boolean(),
-          upper: integer(),
+          upper: integer() | :unbound | :empty,
           upper_inclusive: boolean()
         }
 

--- a/lib/pg_ranges/int8range.ex
+++ b/lib/pg_ranges/int8range.ex
@@ -5,9 +5,9 @@ defmodule PgRanges.Int8Range do
   use PgRanges
 
   @type t :: %__MODULE__{
-          lower: integer(),
+          lower: integer() | :unbound | :empty,
           lower_inclusive: boolean(),
-          upper: integer(),
+          upper: integer() | :unbound | :empty,
           upper_inclusive: boolean()
         }
 

--- a/lib/pg_ranges/numrange.ex
+++ b/lib/pg_ranges/numrange.ex
@@ -5,9 +5,9 @@ defmodule PgRanges.NumRange do
   use PgRanges
 
   @type t :: %__MODULE__{
-          lower: float(),
+          lower: float() | :unbound | :empty,
           lower_inclusive: boolean(),
-          upper: float(),
+          upper: float() | :unbound | :empty,
           upper_inclusive: boolean()
         }
 
@@ -92,6 +92,9 @@ defmodule PgRanges.NumRange do
     struct!(__MODULE__, fields)
   end
 
+  defp to_decimal(value)
+  defp to_decimal(:unbound), do: :unbound
+  defp to_decimal(:empty), do: :empty
   defp to_decimal(value) when is_float(value), do: Decimal.from_float(value)
   defp to_decimal(value), do: Decimal.new(value)
 end

--- a/lib/pg_ranges/tsrange.ex
+++ b/lib/pg_ranges/tsrange.ex
@@ -5,9 +5,9 @@ defmodule PgRanges.TsRange do
   use PgRanges
 
   @type t :: %__MODULE__{
-          lower: NaiveDateTime.t(),
+          lower: NaiveDateTime.t() | :unbound | :empty,
           lower_inclusive: boolean(),
-          upper: NaiveDateTime.t(),
+          upper: NaiveDateTime.t() | :unbound | :empty,
           upper_inclusive: boolean()
         }
 

--- a/lib/pg_ranges/tstzrange.ex
+++ b/lib/pg_ranges/tstzrange.ex
@@ -5,9 +5,9 @@ defmodule PgRanges.TstzRange do
   use PgRanges
 
   @type t :: %__MODULE__{
-          lower: DateTime.t(),
+          lower: DateTime.t() | :unbound | :empty,
           lower_inclusive: boolean(),
-          upper: DateTime.t(),
+          upper: DateTime.t() | :unbound | :empty,
           upper_inclusive: boolean()
         }
 
@@ -29,11 +29,21 @@ defmodule PgRanges.TstzRange do
   @impl true
   def new(lower, upper, opts \\ []) do
     time_zone_database = Keyword.get(opts, :time_zone_database, Calendar.get_time_zone_database())
-    {:ok, lower} = DateTime.shift_zone(lower, "Etc/UTC", time_zone_database)
-    {:ok, upper} = DateTime.shift_zone(upper, "Etc/UTC", time_zone_database)
+
+    lower = shift_to_utc(lower, time_zone_database)
+    upper = shift_to_utc(upper, time_zone_database)
 
     fields = Keyword.merge(opts, lower: lower, upper: upper)
 
     struct!(__MODULE__, fields)
+  end
+
+  defp shift_to_utc(date_time, time_zone_database)
+  defp shift_to_utc(:unbound, _time_zone_database), do: :unbound
+  defp shift_to_utc(:empty, _time_zone_database), do: :empty
+
+  defp shift_to_utc(date_time, time_zone_database) do
+    {:ok, date_time} = DateTime.shift_zone(date_time, "UTC", time_zone_database)
+    date_time
   end
 end

--- a/lib/pg_ranges/tstzrange.ex
+++ b/lib/pg_ranges/tstzrange.ex
@@ -43,7 +43,8 @@ defmodule PgRanges.TstzRange do
   defp shift_to_utc(:empty, _time_zone_database), do: :empty
 
   defp shift_to_utc(date_time, time_zone_database) do
-    {:ok, date_time} = DateTime.shift_zone(date_time, "UTC", time_zone_database)
+    {:ok, date_time} = DateTime.shift_zone(date_time, "Etc/UTC", time_zone_database)
+
     date_time
   end
 end

--- a/test/pg_ranges_test.exs
+++ b/test/pg_ranges_test.exs
@@ -20,7 +20,7 @@ defmodule PgRanges.PgRangesTest do
     NumMultirange
   }
 
-  setup do
+  test "querying" do
     date_range = DateRange.new(~D[2018-04-21], ~D[2018-04-22])
     ts_range = TsRange.new(~N[2018-04-21 15:00:00], ~N[2018-04-22 01:00:00])
 
@@ -69,9 +69,7 @@ defmodule PgRanges.PgRangesTest do
       |> Repo.insert()
 
     {:ok, model: m, now: now}
-  end
 
-  test "querying" do
     range = Int4Range.new(1, 4)
 
     models =
@@ -137,5 +135,49 @@ defmodule PgRanges.PgRangesTest do
       )
 
     assert length(models) == 0
+  end
+
+  test "can handle open ended ranges" do
+    assert {:ok, _model} =
+             Model.changeset(%Model{}, %{
+               date: DateRange.new(:unbound, :unbound),
+               ts: TsRange.new(:unbound, :unbound),
+               tstz: TstzRange.new(:unbound, :unbound),
+               int4: Int4Range.new(:unbound, :unbound),
+               int8: Int8Range.new(:unbound, :unbound),
+               num: NumRange.new(:unbound, :unbound)
+             })
+             |> Repo.insert()
+
+    assert %Model{
+             date: %DateRange{lower: :unbound, upper: :unbound},
+             ts: %TsRange{lower: :unbound, upper: :unbound},
+             tstz: %TstzRange{lower: :unbound, upper: :unbound},
+             int4: %Int4Range{lower: :unbound, upper: :unbound},
+             int8: %Int8Range{lower: :unbound, upper: :unbound},
+             num: %NumRange{lower: :unbound, upper: :unbound}
+           } = Repo.one(Model)
+  end
+
+  test "can handle empty range" do
+    assert {:ok, _model} =
+             Model.changeset(%Model{}, %{
+               date: DateRange.new(:empty, :empty),
+               ts: TsRange.new(:empty, :empty),
+               tstz: TstzRange.new(:empty, :empty),
+               int4: Int4Range.new(:empty, :empty),
+               int8: Int8Range.new(:empty, :empty),
+               num: NumRange.new(:empty, :empty)
+             })
+             |> Repo.insert()
+
+    assert %Model{
+             date: %DateRange{lower: :empty, upper: :empty},
+             ts: %TsRange{lower: :empty, upper: :empty},
+             tstz: %TstzRange{lower: :empty, upper: :empty},
+             int4: %Int4Range{lower: :empty, upper: :empty},
+             int8: %Int8Range{lower: :empty, upper: :empty},
+             num: %NumRange{lower: :empty, upper: :empty}
+           } = Repo.one(Model)
   end
 end

--- a/test/pg_ranges_test.exs
+++ b/test/pg_ranges_test.exs
@@ -20,124 +20,128 @@ defmodule PgRanges.PgRangesTest do
     NumMultirange
   }
 
-  test "querying" do
-    date_range = DateRange.new(~D[2018-04-21], ~D[2018-04-22])
-    ts_range = TsRange.new(~N[2018-04-21 15:00:00], ~N[2018-04-22 01:00:00])
+  describe "bounded ranges" do
+    setup do
+      date_range = DateRange.new(~D[2018-04-21], ~D[2018-04-22])
+      ts_range = TsRange.new(~N[2018-04-21 15:00:00], ~N[2018-04-22 01:00:00])
 
-    tstz_range =
-      TstzRange.new(
-        DateTime.from_naive!(~N[2018-04-21 15:00:00], "America/Chicago"),
-        DateTime.from_naive!(~N[2018-04-22 01:00:00], "America/Chicago")
-      )
+      tstz_range =
+        TstzRange.new(
+          DateTime.from_naive!(~N[2018-04-21 15:00:00], "America/Chicago"),
+          DateTime.from_naive!(~N[2018-04-22 01:00:00], "America/Chicago")
+        )
 
-    int4_range = Int4Range.new(0, 10)
-    int8_range = Int8Range.new(0, 1_000_000_000)
-    num_range = NumRange.new(0, 9.9, upper_inclusive: true)
+      int4_range = Int4Range.new(0, 10)
+      int8_range = Int8Range.new(0, 1_000_000_000)
+      num_range = NumRange.new(0, 9.9, upper_inclusive: true)
 
-    now = DateTime.utc_now()
+      now = DateTime.utc_now()
 
-    date_multi = DateMultirange.new([date_range, DateRange.new(~D[2018-04-23], ~D[2018-04-24])])
+      date_multi = DateMultirange.new([date_range, DateRange.new(~D[2018-04-23], ~D[2018-04-24])])
 
-    ts_multi =
-      TsMultirange.new([ts_range, TsRange.new(~N[2018-04-23 15:00:00], ~N[2018-04-24 01:00:00])])
+      ts_multi =
+        TsMultirange.new([ts_range, TsRange.new(~N[2018-04-23 15:00:00], ~N[2018-04-24 01:00:00])])
 
-    tstz_multirange =
-      TstzMultirange.new([
-        TstzRange.new(now, DateTime.add(now, 1, :hour)),
-        TstzRange.new(DateTime.add(now, 2, :hour), DateTime.add(now, 3, :hour))
-      ])
+      tstz_multirange =
+        TstzMultirange.new([
+          TstzRange.new(now, DateTime.add(now, 1, :hour)),
+          TstzRange.new(DateTime.add(now, 2, :hour), DateTime.add(now, 3, :hour))
+        ])
 
-    int4_multi = Int4Multirange.new([int4_range, Int4Range.new(11, 20)])
-    int8_multi = Int8Multirange.new([int8_range, Int8Range.new(1_000_000_001, 2_000_000_000)])
-    num_multi = NumMultirange.new([num_range, NumRange.new(10.0, 19.9, upper_inclusive: true)])
+      int4_multi = Int4Multirange.new([int4_range, Int4Range.new(11, 20)])
+      int8_multi = Int8Multirange.new([int8_range, Int8Range.new(1_000_000_001, 2_000_000_000)])
+      num_multi = NumMultirange.new([num_range, NumRange.new(10.0, 19.9, upper_inclusive: true)])
 
-    {:ok, m} =
-      Model.changeset(%Model{}, %{
-        date: date_range,
-        ts: ts_range,
-        tstz: tstz_range,
-        int4: int4_range,
-        int8: int8_range,
-        num: num_range,
-        datemulti: date_multi,
-        tsmulti: ts_multi,
-        tstzmulti: tstz_multirange,
-        int4multi: int4_multi,
-        int8multi: int8_multi,
-        nummulti: num_multi
-      })
-      |> Repo.insert()
+      {:ok, m} =
+        Model.changeset(%Model{}, %{
+          date: date_range,
+          ts: ts_range,
+          tstz: tstz_range,
+          int4: int4_range,
+          int8: int8_range,
+          num: num_range,
+          datemulti: date_multi,
+          tsmulti: ts_multi,
+          tstzmulti: tstz_multirange,
+          int4multi: int4_multi,
+          int8multi: int8_multi,
+          nummulti: num_multi
+        })
+        |> Repo.insert()
 
-    {:ok, model: m, now: now}
+      {:ok, model: m, now: now}
+    end
 
-    range = Int4Range.new(1, 4)
+    test "querying" do
+      range = Int4Range.new(1, 4)
 
-    models =
-      Repo.all(from(m in Model, where: fragment("? @> ?", m.int4, type(^range, Int4Range))))
+      models =
+        Repo.all(from(m in Model, where: fragment("? @> ?", m.int4, type(^range, Int4Range))))
 
-    assert length(models) == 1
+      assert length(models) == 1
+    end
+
+    test "querying tstzrange" do
+      tzdb = Calendar.get_time_zone_database()
+
+      inside =
+        DateTime.from_naive!(~N[2018-04-21 15:30:00], "America/Chicago")
+        |> DateTime.shift_zone!("Etc/UTC", tzdb)
+
+      outside =
+        DateTime.from_naive!(~N[2018-04-21 14:30:00], "America/Chicago")
+        |> DateTime.shift_zone!("Etc/UTC", tzdb)
+
+      models =
+        Repo.all(
+          from(m in Model, where: fragment("? @> ?::timestamp with time zone", m.tstz, ^inside))
+        )
+
+      assert length(models) == 1
+
+      models =
+        Repo.all(
+          from(m in Model, where: fragment("? @> ?::timestamp with time zone", m.tstz, ^outside))
+        )
+
+      assert length(models) == 0
+    end
+
+    test "querying tstzmultirange", %{now: now} do
+      inside1 = DateTime.add(now, 30, :minute)
+      inside2 = DateTime.add(now, 150, :minute)
+      outside = DateTime.add(now, 500, :minute)
+
+      models =
+        Repo.all(
+          from(m in Model,
+            where: fragment("? @> ?::timestamp with time zone", m.tstzmulti, ^inside1)
+          )
+        )
+
+      assert length(models) == 1
+
+      models =
+        Repo.all(
+          from(m in Model,
+            where: fragment("? @> ?::timestamp with time zone", m.tstzmulti, ^inside2)
+          )
+        )
+
+      assert length(models) == 1
+
+      models =
+        Repo.all(
+          from(m in Model,
+            where: fragment("? @> ?::timestamp with time zone", m.tstzmulti, ^outside)
+          )
+        )
+
+      assert length(models) == 0
+    end
   end
 
-  test "querying tstzrange" do
-    tzdb = Calendar.get_time_zone_database()
-
-    inside =
-      DateTime.from_naive!(~N[2018-04-21 15:30:00], "America/Chicago")
-      |> DateTime.shift_zone!("Etc/UTC", tzdb)
-
-    outside =
-      DateTime.from_naive!(~N[2018-04-21 14:30:00], "America/Chicago")
-      |> DateTime.shift_zone!("Etc/UTC", tzdb)
-
-    models =
-      Repo.all(
-        from(m in Model, where: fragment("? @> ?::timestamp with time zone", m.tstz, ^inside))
-      )
-
-    assert length(models) == 1
-
-    models =
-      Repo.all(
-        from(m in Model, where: fragment("? @> ?::timestamp with time zone", m.tstz, ^outside))
-      )
-
-    assert length(models) == 0
-  end
-
-  test "querying tstzmultirange", %{now: now} do
-    inside1 = DateTime.add(now, 30, :minute)
-    inside2 = DateTime.add(now, 150, :minute)
-    outside = DateTime.add(now, 500, :minute)
-
-    models =
-      Repo.all(
-        from(m in Model,
-          where: fragment("? @> ?::timestamp with time zone", m.tstzmulti, ^inside1)
-        )
-      )
-
-    assert length(models) == 1
-
-    models =
-      Repo.all(
-        from(m in Model,
-          where: fragment("? @> ?::timestamp with time zone", m.tstzmulti, ^inside2)
-        )
-      )
-
-    assert length(models) == 1
-
-    models =
-      Repo.all(
-        from(m in Model,
-          where: fragment("? @> ?::timestamp with time zone", m.tstzmulti, ^outside)
-        )
-      )
-
-    assert length(models) == 0
-  end
-
-  test "can handle open ended ranges" do
+  test "can handle lower and upper open ended ranges" do
     assert {:ok, _model} =
              Model.changeset(%Model{}, %{
                date: DateRange.new(:unbound, :unbound),
@@ -156,6 +160,67 @@ defmodule PgRanges.PgRangesTest do
              int4: %Int4Range{lower: :unbound, upper: :unbound},
              int8: %Int8Range{lower: :unbound, upper: :unbound},
              num: %NumRange{lower: :unbound, upper: :unbound}
+           } = Repo.one(Model)
+  end
+
+  test "can handle lower open ended ranges" do
+    date_range = DateRange.new(~D[2018-04-21], :unbound)
+    ts_range = TsRange.new(~N[2018-04-21 15:00:00.000000], :unbound)
+    tstz_range = TstzRange.new(~U[2018-04-21 20:00:00.000000Z], :unbound)
+
+    int4_range = Int4Range.new(0, :unbound)
+    int8_range = Int8Range.new(0, :unbound)
+    num_range = NumRange.new(0, :unbound)
+
+    assert {:ok, _model} =
+             Model.changeset(%Model{}, %{
+               date: date_range,
+               ts: ts_range,
+               tstz: tstz_range,
+               int4: int4_range,
+               int8: int8_range,
+               num: num_range
+             })
+             |> Repo.insert()
+
+    assert %Model{
+             date: ^date_range,
+             ts: ^ts_range,
+             tstz: ^tstz_range,
+             int4: ^int4_range,
+             int8: ^int8_range,
+             num: ^num_range
+           } = Repo.one(Model)
+  end
+
+  test "can handle upper open ended ranges" do
+    # The `upper_inclusive` opts below are here to match default database retrieval behaviour
+    # https://github.com/elixir-ecto/postgrex/pull/655
+    date_range = DateRange.new(:unbound, ~D[2018-04-21], upper_inclusive: false)
+    ts_range = TsRange.new(:unbound, ~N[2018-04-21 15:00:00.000000])
+    tstz_range = TstzRange.new(:unbound, ~U[2018-04-21 20:00:00.000000Z])
+    int4_range = Int4Range.new(:unbound, 0, upper_inclusive: false)
+    int8_range = Int8Range.new(:unbound, 0, upper_inclusive: false)
+    num_range = NumRange.new(:unbound, 0)
+
+    assert {:ok, _model} =
+             Model.changeset(%Model{}, %{
+               date: date_range,
+               ts: ts_range,
+               tstz: tstz_range,
+               int4: int4_range,
+               int8: int8_range,
+               num: num_range
+             })
+             |> Repo.insert()
+
+    assert %Model{
+             date: ^date_range,
+             ts: ^ts_range,
+             tstz: ^tstz_range,
+             int4: ^int4_range,
+             int8: ^int8_range,
+             num: ^num_range
            } = Repo.one(Model)
   end
 
@@ -178,6 +243,28 @@ defmodule PgRanges.PgRangesTest do
              int4: %Int4Range{lower: :empty, upper: :empty},
              int8: %Int8Range{lower: :empty, upper: :empty},
              num: %NumRange{lower: :empty, upper: :empty}
+           } = Repo.one(Model)
+  end
+
+  test "can handle open ended ranges" do
+    assert {:ok, _model} =
+             Model.changeset(%Model{}, %{
+               date: DateRange.new(:unbound, :unbound),
+               ts: TsRange.new(:unbound, :unbound),
+               tstz: TstzRange.new(:unbound, :unbound),
+               int4: Int4Range.new(:unbound, :unbound),
+               int8: Int8Range.new(:unbound, :unbound),
+               num: NumRange.new(:unbound, :unbound)
+             })
+             |> Repo.insert()
+
+    assert %Model{
+             date: %DateRange{lower: :unbound, upper: :unbound},
+             ts: %TsRange{lower: :unbound, upper: :unbound},
+             tstz: %TstzRange{lower: :unbound, upper: :unbound},
+             int4: %Int4Range{lower: :unbound, upper: :unbound},
+             int8: %Int8Range{lower: :unbound, upper: :unbound},
+             num: %NumRange{lower: :unbound, upper: :unbound}
            } = Repo.one(Model)
   end
 end


### PR DESCRIPTION
Hello, I've taken the @maennchen's PR that's already exists https://github.com/vforgione/pg_ranges/pull/17, and I've added the tests you were asking for.

I've also adjusted the defaults of ranges. Now when the value is `nil`, `unbound` or `empty` the `inclusive` value is defaulted to `false` as it doesn't really makes sense for unbounded range to be inclusive. 
I've also made so that if there's a value, the default `inclusive` is set to `true` to match Elixir's default behaviour of ranges being inclusive. 

While doing so, I've discovered that postgres does not return the ranges exactly how they are stored https://github.com/elixir-ecto/postgrex/pull/655. That means that sometime the input can be different than the output in terms of inclusiveness.